### PR TITLE
Avoid random seed cycles by seeding off time in TB-3PO

### DIFF
--- a/software/o_c_REV/HEM_TB3PO.ino
+++ b/software/o_c_REV/HEM_TB3PO.ino
@@ -78,7 +78,7 @@ class TB_3PO : public HemisphereApplet
       transpose_note_in = 0;    
 
       lock_seed = 0;
-      seed = random(0, 65535); // 16 bits
+      reseed();
       regenerate_all();
 
     }
@@ -96,7 +96,7 @@ class TB_3PO : public HemisphereApplet
         // Otherwise, the user has locked it, so leave it as set
         if(lock_seed == 0)
         {
-          seed = random(0, 65535); // 16 bits
+          reseed();
         }
 
         // Apply the seed to regenerate the pattern`
@@ -487,8 +487,13 @@ class TB_3PO : public HemisphereApplet
       int32_t cv_note = quantizer.Lookup( constrain(quant_note, 0, 127));
       display_semi_quantizer.Process(cv_note, 0, 0);  // Use root == 0 to start at c
       return display_semi_quantizer.GetLatestNoteNumber() % 12;
-    }
+    } 
 
+    void reseed()
+    {
+      randomSeed(micros());
+      seed = random(0, 65535); // 16 bits
+    }
     
   	// Trigger generating the sequence deterministically using the seed (over the next couple of Controller() calls)
   	void regenerate_all()


### PR DESCRIPTION
Previously, seed generation would get caught in a cycle of about 38 seeds. To reproduce, keep generating new seeds until you see the state `bbbc`. Then, keep generating new seeds about 38 times, and that seed will appear again. I have to confess, I was pretty surprised with this behavior and only discovered it as I had left TB-3PO jamming in background for several hours and noticed I kept hearing the same lines over and over.

This PR fixes this by reseeding off of the amount of microseconds that the o_C has been running. Thus, while patterns are still deterministic off the seed (and unchanged by this patch), the sequence of seeds is non-deterministic.

This non-determinism could be viewed as a bad thing if someone was relying on a particular sequence of seeds. Personally, I would definitely not expect the sequence of seeds to be deterministic, but happy to look into other strategies.